### PR TITLE
Update mock.js

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -84,7 +84,13 @@ const storage = {}; // Root storage.
 			Object.defineProperty(this, 'version', { value: version, enumerable: true });
 			Object.defineProperty(this, 'objectStoreNames', {
 				enumerable: true,
-				get() { const names = Object.keys(data); names.sort(); return names; },
+				get() {
+					const names = Object.keys(data);
+					names.sort();
+					// Fake contains from DOMStringList
+					names.contains = (valueTest) => names.indexOf(valueTest) !== -1;
+					return names;
+				},
 				set() { throw new Error('IDBDatabase: _data is read only'); }
 			});
 			Object.defineProperty(this, '_data', {


### PR DESCRIPTION
Adds contains to objectSotreNames https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#the-domstringlist-interface

The shelving indexedDBmock just returns an array, but indexOf isn't valid in the browser, so there isn't anything I can do.