### PR TITLE
Allow for Edge / IE behavior with openCursor when query is null

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -730,8 +730,13 @@ const storage = {}; // Root storage.
 			// 2. `undefined`, if there are no more results.
 			function openCursor(query = undefined, direction = 'next')
 			{
+				if (query === null)
+				{
+					// Edge / IE allow for 'null' to be passed, but it is treated as 'undefined' for mock purposes.
+					query = undefined;
+				}
 				// Check params.
-				if (!validKey(query) && !validKeyRange(query) && query !== undefined) throw new DOMException('count(): The query parameter not contain a valid key (number, string, date), key range (IDBKeyRange or array of valid keys), or undefined', 'DataError');
+				if (!validKey(query) && !validKeyRange(query) && query !== undefined) throw new DOMException('count(): The query parameter was provided but does not contain a valid key (number, string, date), key range (IDBKeyRange or array of valid keys), or, it is not null or undefined', 'DataError');
 				if (direction !== 'next' && direction !== 'prev') throw new TypeError('IDBCursor: direction must be one of \'next\' or \'prev\' (\'nextunique\' or \'prevunique\' are not relevant for primary keys, which must be unique)');
 
 				// Check state.
@@ -1015,8 +1020,13 @@ const storage = {}; // Root storage.
 			// 2. `undefined`, if there are no more results.
 			function openCursor(query = undefined, direction = 'next')
 			{
+				if (query === null)
+				{
+					// Edge / IE allow for 'null' to be passed, but it is treated as 'undefined' for mock purposes.
+					query = undefined;
+				}
 				// Check params.
-				if (!validKey(query) && !validKeyRange(query) && query !== undefined) throw new DOMException('count(): The query parameter was provided but does not contain a valid key (number, string, date), key range (IDBKeyRange or array of valid keys), or undefined', 'DataError');
+				if (!validKey(query) && !validKeyRange(query) && query !== undefined) throw new DOMException('count(): The query parameter was provided but does not contain a valid key (number, string, date), key range (IDBKeyRange or array of valid keys), or, it is not null or undefined', 'DataError');
 				if (direction !== 'next' && direction !== 'nextunique' && direction !== 'prev' && direction !== 'prevunique') throw new TypeError('IDBCursor: direction must be one of \'next\', \'nextunique\', \'prev\', \'prevunique\'');
 
 				// Check state.


### PR DESCRIPTION
Edge / IE throw incorrect exceptions when `undefined` is used as a parameter for the query for `openCursor`.

Because of this, users of IndexedDB in their actual code will pass `null` when they would want to use `undefined`. 

This updates this mocking library to allow for developers who use `null` in Edge / IE compliant code to behave as if it was `undefined`.